### PR TITLE
fix: all the bugs

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeLogic.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeLogic.java
@@ -235,14 +235,13 @@ public class CraftingRecipeLogic extends SyncHandler {
 
             boolean matchedPreviously = false;
             if (map.containsKey(itemStack)) {
-                if (!map.get(itemStack)) {
-                    continue;
+                if (map.get(itemStack)) {
+                    // cant return here before checking if:
+                    // The item is available for extraction
+                    // The recipe output is still the same, as depending on
+                    // the ingredient, the output NBT may change
+                    matchedPreviously = true;
                 }
-                // cant return here before checking if:
-                // The item is available for extraction
-                // The recipe output is still the same, as depending on
-                // the ingredient, the output NBT may change
-                matchedPreviously = true;
             }
 
             if (!matchedPreviously) {
@@ -351,6 +350,7 @@ public class CraftingRecipeLogic extends SyncHandler {
             var slotStack = slot.getStack();
             if (slotStack.isEmpty()) {
                 slot.hasIngredients = true;
+                map.put(slot.getIndex(), slot.hasIngredients);
                 continue;
             }
 
@@ -427,6 +427,7 @@ public class CraftingRecipeLogic extends SyncHandler {
                 try {
                     this.craftingMatrix.setInventorySlotContents(i, buf.readItemStack());
                 } catch (IOException ignore) {}
+                this.updateCurrentRecipe();
             }
         } else if (id == 4) {
             int slot = buf.readVarInt();

--- a/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeMemory.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeMemory.java
@@ -185,6 +185,7 @@ public class CraftingRecipeMemory extends SyncHandler {
             buf.writeByte(recipe.index);
             buf.writeItemStack(recipe.recipeResult);
             buf.writeInt(recipe.timesUsed);
+            buf.writeBoolean(recipe.isRecipeLocked());
         }
     }
 
@@ -197,6 +198,7 @@ public class CraftingRecipeMemory extends SyncHandler {
 
             memorizedRecipes[index].recipeResult = readStackSafe(buf);
             memorizedRecipes[index].timesUsed = buf.readInt();
+            memorizedRecipes[index].recipeLocked = buf.readBoolean();
         }
     }
 

--- a/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
@@ -76,15 +76,13 @@ public class CraftingInputSlot extends Widget<CraftingOutputSlot> implements Int
         ItemStack itemstack = this.syncHandler.getStack();
         if (itemstack.isEmpty()) return;
 
-        if (!this.hasIngredients) {
-            RenderUtil.renderRect(0, 0, 18, 18, 100, 0x80FF0000);
-        }
-
-        guiScreen.setZ(100f);
-        guiScreen.getItemRenderer().zLevel = 100f;
-        RenderUtil.renderItemInGUI(itemstack, 1, 1);
         guiScreen.getItemRenderer().zLevel = 0.0F;
         guiScreen.setZ(0f);
+        RenderUtil.renderItemInGUI(itemstack, 1, 1);
+
+        if (!this.hasIngredients) {
+            RenderUtil.renderRect(0, 0, 18, 18, 200, 0x80FF0000);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/mui/widget/workbench/RecipeMemorySlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/RecipeMemorySlot.java
@@ -4,6 +4,7 @@ import gregtech.api.mui.GTGuiTextures;
 import gregtech.client.utils.RenderUtil;
 import gregtech.common.metatileentities.storage.CraftingRecipeMemory;
 
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
@@ -49,8 +50,11 @@ public class RecipeMemorySlot extends Widget<RecipeMemorySlot> implements Intera
         RenderUtil.renderItemInGUI(itemstack, 1, 1);
         itemstack.setCount(cachedCount);
 
-        if (this.memory.getRecipeAtIndex(this.index).isRecipeLocked())
+        if (this.memory.getRecipeAtIndex(this.index).isRecipeLocked()) {
+            GlStateManager.disableDepth();
             GTGuiTextures.RECIPE_LOCK.draw(context, 10, 1, 8, 8, widgetTheme);
+            GlStateManager.enableDepth();
+        }
 
         guiScreen.getItemRenderer().zLevel = 0.0F;
         guiScreen.setZ(0f);


### PR DESCRIPTION
Fixes a few bugs:
- Items are now actually substituted 
- Potential server-client cache recipe desyncs have been averted
- Memory locking is synced in all required places now
- Red tint goes _over_ the items now (so that people can always see it)
- Locks also go over the items now
- A red tint desync based on empty slots is fixed